### PR TITLE
Add pipeline hook ModifyNewBullet

### DIFF
--- a/lua/arc9/shared/sh_physbullet.lua
+++ b/lua/arc9/shared/sh_physbullet.lua
@@ -100,6 +100,11 @@ function ARC9:ShootPhysBullet(wep, pos, vel, tbl)
     if bit.band( util.PointContents( pos ), CONTENTS_WATER ) == CONTENTS_WATER then
         bullet.Underwater = true
     end
+    
+    if bullet.Fancy then
+        wep:RunHook("HookP_ModifyNewBullet", bullet)
+        if bullet.Dead then return end
+    end
 
     table.insert(ARC9.PhysBullets, bullet)
 

--- a/lua/arc9/shared/sh_physbullet.lua
+++ b/lua/arc9/shared/sh_physbullet.lua
@@ -101,10 +101,8 @@ function ARC9:ShootPhysBullet(wep, pos, vel, tbl)
         bullet.Underwater = true
     end
     
-    if bullet.Fancy then
-        wep:RunHook("HookP_ModifyNewBullet", bullet)
-        if bullet.Dead then return end
-    end
+    wep:RunHook("HookP_ModifyNewBullet", bullet)
+    if bullet.Dead then return end
 
     table.insert(ARC9.PhysBullets, bullet)
 

--- a/lua/weapons/arc9_base/shared.lua
+++ b/lua/weapons/arc9_base/shared.lua
@@ -363,6 +363,7 @@ SWEP.MalfunctionMeanShotsToFail = 1000 -- The mean number of shots between malfu
 -- SWEP.Hook_ModifyRecoilDir = function(self, dir) return dir end # direction of recoil in degrees, 0 = up
 -- SWEP.HookP_ModifyFiremode = function(self, firemode) return firemode end
 -- SWEP.HookP_ModifyBullet = function(self, bullet) return end # bullet = phys bullet table, modify in place, does not accept return
+-- SWEP.HookP_ModifyNewBullet = function(self, bullet) return end # bullet = phys bullet table, modify in place, does not accept return
 -- SWEP.HookP_BlockFire = function(self) return block end # return true to block firing
 -- SWEP.Hook_ModifyBodygroups = function(self, data) return end # data = {model = Model, elements = {"table" = true, "of" = true, "elements" = true}}
 


### PR DESCRIPTION
Allows for a fancy physbullet to have its table immediately modified before being added to the PhysBullet table. Can be set to dead to just skip even adding it to the table for whatever reason.