### PR TITLE
Update cl_tpik.lua to allow SWEP.NoTPIK to work

### DIFF
--- a/lua/weapons/arc9_base/cl_tpik.lua
+++ b/lua/weapons/arc9_base/cl_tpik.lua
@@ -4,6 +4,7 @@ function SWEP:ShouldTPIK()
     if render.GetDXLevel() < 90 then return false end
     if !self:GetOwner():IsPlayer() then return false end
     if !self.MirrorVMWM then return end
+    if self.NoTPIK then return end
     if self:GetSafe() then return false end
     -- if self:GetBlindFireAmount() > 0 then return false end
     if LocalPlayer() == self:GetOwner() and !self:GetOwner():ShouldDrawLocalPlayer() then return false end


### PR DESCRIPTION
Currently, SWEP.NoTPIK = true in the weapon's lua file does nothing.

This simple fix allows it to work.

Tested in-game with success.