### PR TITLE
Animations for manual reloading for weapons like the revolver

### DIFF
--- a/lua/weapons/arc9_base/sh_anim.lua
+++ b/lua/weapons/arc9_base/sh_anim.lua
@@ -183,8 +183,19 @@ end
 function SWEP:Idle()
     if self:GetPrimedAttack() then return end
     if self:GetSafe() then return end
-
-    self:PlayAnimation("idle")
+	
+	local anim = "idle"
+	local clip = self:Clip1()
+	local banim = anim
+	
+	for i = 1, self:GetCapacity(self:GetUBGL()) - clip do
+            if self:HasAnimation(anim .. "_" .. tostring(i)) then
+                banim = anim .. "_" .. tostring(i)
+			end
+        end
+	anim = banim
+	
+    self:PlayAnimation(anim)
 end
 
 SWEP.PoseParamState = {}

--- a/lua/weapons/arc9_base/sh_reload.lua
+++ b/lua/weapons/arc9_base/sh_reload.lua
@@ -66,10 +66,25 @@ function SWEP:Reload()
 
     if self:GetShouldShotgunReload() then
         anim = "reload_start"
-
+	
         if self:GetUBGL() then
             anim = "reload_ubgl_start"
         end
+		
+		local nanim = anim
+			
+		for i = 1, self:GetCapacity(self:GetUBGL()) - clip do
+            if self:HasAnimation(anim .. "_" .. tostring(i)) then
+                nanim = anim .. "_" .. tostring(i)
+			end
+        end
+			
+		anim = nanim
+		
+    end
+	
+	if !self:GetProcessedValue("ReloadInSights") then
+        self:ExitSights()
     end
 
     anim = self:RunHook("Hook_SelectReloadAnimation", anim) or anim
@@ -119,9 +134,7 @@ function SWEP:Reload()
     self:ToggleBlindFire(false)
     self:SetRequestReload(false)
 
-    if !self:GetProcessedValue("ReloadInSights") then
-        self:ExitSights()
-    end
+    
 
     -- self:SetTimer(t * 0.9, function()
     --     if !IsValid(self) then return end
@@ -291,7 +304,17 @@ function SWEP:EndReload()
             if self:GetUBGL() then
                 anim = "reload_ubgl_finish"
             end
-
+			
+			local canim = anim
+			
+			for i = 1, self:GetCapacity(self:GetUBGL()) - clip do
+                if self:HasAnimation(anim .. "_" .. tostring(i)) then
+                    canim = anim .. "_" .. tostring(i)
+				end
+            end
+			
+			anim = canim
+			
             self:PlayAnimation(anim, self:GetProcessedValue("ReloadTime", 1), true)
             self:SetReloading(false)
 
@@ -311,6 +334,9 @@ function SWEP:EndReload()
                 if self:HasAnimation(anim .. "_" .. tostring(i)) then
                     banim = anim .. "_" .. tostring(i)
                     attempt_to_restore = i
+				elseif self:HasAnimation(anim .. "_bullet_" .. tostring(i)) then
+                    banim = anim .. "_bullet_" .. tostring(i)
+                    attempt_to_restore = 1
                 end
             end
 

--- a/lua/weapons/arc9_base/shared.lua
+++ b/lua/weapons/arc9_base/shared.lua
@@ -953,6 +953,7 @@ SWEP.Attachments = {
 -- draw
 -- ready
 -- holster
+-- idle_1, idle_2, idle_3...
 -- fire
 -- fire_1, fire_2, fire_3...
 -- dryfire
@@ -961,7 +962,10 @@ SWEP.Attachments = {
 -- trigger Trigger delay
 -- untrigger Let go of trigger before fire
 -- reload_ubgl
+-- reload_start_1, reload_start_2, reload_start_3...: For reloads that require losing the spent shells. For example removing spent shells on a revolver or double barrel shotgun.
 -- reload_insert_1, reload_insert_2, reload_insert_3...: Animation that reloads multiple rounds in at once, such as a stripper clip.
+-- reload_insert_bullet_1, reload_insert_bullet_2, reload_insert_bullet_3...: Animation that reloads one by one at a time, such as a revolver or double barrel shotguns.
+-- reload_finish, reload_finish_1, reload_finish_2...: Animation that finishes the reload based off of how much bullets you insert in your gun. _# prefix is bullets left to full after cancel reload.
 -- enter_bipod, exit_bipod
 -- enter_inspect, exit_inspect, idle_inspect
 -- jam


### PR DESCRIPTION
Adds a way for revolvers to have manual reloads for every bullet it has and cylinder changes based off of how much bullets left. Moved the ReloadInSights up in the function for SWEP:Reloads so reload_start_# would work. Idle animations now have variations where for example you can see the cylinder change with every shot.