### PR TITLE
Fixes a penetration bug (or possibly feature) that causes double damage.

### DIFF
--- a/lua/weapons/arc9_base/sh_penetration.lua
+++ b/lua/weapons/arc9_base/sh_penetration.lua
@@ -191,26 +191,26 @@ function SWEP:Penetrate(tr, range, penleft, alreadypenned)
                 Indirect = true
             })
         else
-		if !ARC9.IsPointOutOfBounds(endpos) then
-			local bullet_table = {
-				Damage = self:GetValue("Damage_Max"),
-				Force = 4,
-				Tracer = 0,
-				Num = 1,
-				Dir = dir,
-				Src = endpos,
-				Callback = function(att, btr, dmg)
-					range = range + (btr.HitPos - btr.StartPos):Length()
-					self:AfterShotFunction(btr, dmg, range, penleft, alreadypenned)
+			if !ARC9.IsPointOutOfBounds(endpos) then
+				local bullet_table = {
+					Damage = self:GetValue("Damage_Max"),
+					Force = 4,
+					Tracer = 0,
+					Num = 1,
+					Dir = dir,
+					Src = endpos,
+					Callback = function(att, btr, dmg)
+						range = range + (btr.HitPos - btr.StartPos):Length()
+						self:AfterShotFunction(btr, dmg, range, penleft, alreadypenned)
 
-					if ARC9.Dev(2) then
-						if SERVER then
-							debugoverlay.Cross(btr.HitPos, 4, 5, Color(255, 0, 0), false)
-						else
-							debugoverlay.Cross(btr.HitPos, 4, 5, Color(255, 255, 255), false)
+						if ARC9.Dev(2) then
+							if SERVER then
+								debugoverlay.Cross(btr.HitPos, 4, 5, Color(255, 0, 0), false)
+							else
+								debugoverlay.Cross(btr.HitPos, 4, 5, Color(255, 255, 255), false)
+							end
 						end
 					end
-				end
 				}
 				if(table.Count(alreadypenned) == 1) then
 					--We penetrated only one entity.

--- a/lua/weapons/arc9_base/sh_penetration.lua
+++ b/lua/weapons/arc9_base/sh_penetration.lua
@@ -192,7 +192,7 @@ function SWEP:Penetrate(tr, range, penleft, alreadypenned)
             })
         else
             if !ARC9.IsPointOutOfBounds(endpos) then
-                self:GetOwner():FireBullets({
+				local bullet_table = {
                     Damage = self:GetValue("Damage_Max"),
                     Force = 4,
                     Tracer = 0,
@@ -211,7 +211,17 @@ function SWEP:Penetrate(tr, range, penleft, alreadypenned)
                             end
                         end
                     end
-                })
+                }
+				if(table.Count(alreadypenned) == 1) then
+					--We penetrated only one entity.
+					--The reason why we do this for one entity only is that in 99.99% of cases when we penetrate more than one entity, we won't be penetrating the first entity again with the same penetration instance.
+					--God I hope this isn't intensive during firefights, but this is the only way to prevent a double-damage bug where the arm is penetrated and it deals damage to the torso.
+					local first_entity = next(alreadypenned)
+					if(first_entity:GetMaxHealth()) then
+						bullet_table.IgnoreEntity = first_entity
+					end
+				end
+                self:GetOwner():FireBullets(bullet_table)
             end
         end
 

--- a/lua/weapons/arc9_base/sh_penetration.lua
+++ b/lua/weapons/arc9_base/sh_penetration.lua
@@ -191,27 +191,27 @@ function SWEP:Penetrate(tr, range, penleft, alreadypenned)
                 Indirect = true
             })
         else
-            if !ARC9.IsPointOutOfBounds(endpos) then
-				local bullet_table = {
-                    Damage = self:GetValue("Damage_Max"),
-                    Force = 4,
-                    Tracer = 0,
-                    Num = 1,
-                    Dir = dir,
-                    Src = endpos,
-                    Callback = function(att, btr, dmg)
-                        range = range + (btr.HitPos - btr.StartPos):Length()
-                        self:AfterShotFunction(btr, dmg, range, penleft, alreadypenned)
+		if !ARC9.IsPointOutOfBounds(endpos) then
+			local bullet_table = {
+				Damage = self:GetValue("Damage_Max"),
+				Force = 4,
+				Tracer = 0,
+				Num = 1,
+				Dir = dir,
+				Src = endpos,
+				Callback = function(att, btr, dmg)
+					range = range + (btr.HitPos - btr.StartPos):Length()
+					self:AfterShotFunction(btr, dmg, range, penleft, alreadypenned)
 
-                        if ARC9.Dev(2) then
-                            if SERVER then
-                                debugoverlay.Cross(btr.HitPos, 4, 5, Color(255, 0, 0), false)
-                            else
-                                debugoverlay.Cross(btr.HitPos, 4, 5, Color(255, 255, 255), false)
-                            end
-                        end
-                    end
-                }
+					if ARC9.Dev(2) then
+						if SERVER then
+							debugoverlay.Cross(btr.HitPos, 4, 5, Color(255, 0, 0), false)
+						else
+							debugoverlay.Cross(btr.HitPos, 4, 5, Color(255, 255, 255), false)
+						end
+					end
+				end
+				}
 				if(table.Count(alreadypenned) == 1) then
 					--We penetrated only one entity.
 					--The reason why we do this for one entity only is that in 99.99% of cases when we penetrate more than one entity, we won't be penetrating the first entity again with the same penetration instance.
@@ -221,9 +221,9 @@ function SWEP:Penetrate(tr, range, penleft, alreadypenned)
 						bullet_table.IgnoreEntity = first_entity
 					end
 				end
-                self:GetOwner():FireBullets(bullet_table)
-            end
-        end
+				self:GetOwner():FireBullets(bullet_table)
+			end
+		end
 
         if !ARC9.IsPointOutOfBounds(exitpos) then
             self:GetOwner():FireBullets({


### PR DESCRIPTION
Fixes #212

I am not sure if this is a bug or a feature, but during normal combat gameplay, it is possible for you to deal roughly double damage to a target if the model isn't uniform, like a player.

For example, shooting a player in the arm can deal damage and penetrate the arm, while also dealing damage to the torso.

The implementation is kind of weird but it just werks.