### PR TITLE
Update sh_recoil.lua

### DIFF
--- a/lua/weapons/arc9_base/sh_recoil.lua
+++ b/lua/weapons/arc9_base/sh_recoil.lua
@@ -222,8 +222,8 @@ do
 
         
         if !isSingleplayer and ((CLIENT and engine.ServerFrameTime() or FrameTime()) < 0.021) then -- server under 48 tickrate fuck you!!!!!!!!
-            MAGIC1 = 89.5
-            MAGIC2 = 89.5
+            MAGIC1 = 210
+            MAGIC2 = 210
         end
 
         for i = 1, 3 do


### PR DESCRIPTION
A minor modification of sh_recoil.lua that limits the increase of visual recoil in multiplayer by changing the values of MAGIC1 and MAGIC2 in multiplayer from 89.5 to the default 210.