### PR TITLE
Fix Language Selection

### DIFF
--- a/lua/arc9/common/sh_0_i18n.lua
+++ b/lua/arc9/common/sh_0_i18n.lua
@@ -127,6 +127,12 @@ function ARC9:LoadLanguages()
     ARC9:LoadLanguage(_, true)
     ARC9:LoadLanguage(gmod_language:GetString())
     ARC9:LoadLanguage("en")
+    ARC9:LoadLanguage("de")
+    ARC9:LoadLanguage("es-es")
+    ARC9:LoadLanguage("ru")
+    ARC9:LoadLanguage("sv-se")
+    ARC9:LoadLanguage("uwu")
+    ARC9:LoadLanguage("zh-cn")
 end
 
 ARC9:LoadLanguages()


### PR DESCRIPTION
When selecting a different language the new language won't be applied and when re-opening the language menu it will throw a Lua error saying the translation file was not found.

This pull request fixes it by doing AddCSLuaFile() through LoadLanguage()