### PR TITLE
added MidAirCrouch, Water, M2 and CHook conditions on sh_stats.lua

### DIFF
--- a/lua/weapons/arc9_base/sh_stats.lua
+++ b/lua/weapons/arc9_base/sh_stats.lua
@@ -520,6 +520,10 @@ do
             local ownerOnGround = entityOnGround(owner)
 	    local ply = self:GetOwner()
 	    local ownerUnderWater = ply:WaterLevel()
+
+	    if ply:KeyDown(IN_ATTACK2) then
+		stat = arcGetValue(self, val, stat, "M2")
+	    end
 			
             if not ownerOnGround or entityGetMoveType(owner) == MOVETYPE_NOCLIP and not ownerUnderWater == 3 then
                 stat = arcGetValue(self, val, stat, "MidAir")

--- a/lua/weapons/arc9_base/sh_stats.lua
+++ b/lua/weapons/arc9_base/sh_stats.lua
@@ -522,14 +522,24 @@ do
             if not ownerOnGround or entityGetMoveType(owner) == MOVETYPE_NOCLIP then
                 stat = arcGetValue(self, val, stat, "MidAir")
             end
-
+			
+	    if not ownerOnGround and playerCrouching(owner) then
+                stat = arcGetValue(self, val, stat, "MidAirCrouch")
+            end
+				
+	    local ConditionHook = self:RunHook("Hook_ConditionHook", ConditionHook) or false
+			
+	    if ConditionHook == true then
+                stat = arcGetValue(self, val, stat, "CHook")
+            end
+			
             if ownerOnGround and playerCrouching(owner) then
                 stat = arcGetValue(self, val, stat, "Crouch")
             end
 			
-			if ownerOnGround and playerSprinting(owner) and !self:StillWaiting() then
+	    if ownerOnGround and playerSprinting(owner) and !self:StillWaiting() then
                 stat = arcGetValue(self, val, stat, "Sprint")
-			end
+	    end
         end
 
         if swepDt.Reloading then

--- a/lua/weapons/arc9_base/sh_stats.lua
+++ b/lua/weapons/arc9_base/sh_stats.lua
@@ -518,14 +518,20 @@ do
 
         if not ownerIsNPC and entityIsValid(owner) then
             local ownerOnGround = entityOnGround(owner)
-
-            if not ownerOnGround or entityGetMoveType(owner) == MOVETYPE_NOCLIP then
+	    local ply = self:GetOwner()
+	    local ownerUnderWater = ply:WaterLevel()
+			
+            if not ownerOnGround or entityGetMoveType(owner) == MOVETYPE_NOCLIP and not ownerUnderWater == 3 then
                 stat = arcGetValue(self, val, stat, "MidAir")
             end
 			
-	    if not ownerOnGround and playerCrouching(owner) then
+	    if not ownerOnGround and playerCrouching(owner) and not ownerUnderWater == 3 then
                 stat = arcGetValue(self, val, stat, "MidAirCrouch")
             end
+
+	    if ownerUnderWater == 3 then
+	    	stat = arcGetValue(self, val, stat, "Water")
+	    end
 				
 	    local ConditionHook = self:RunHook("Hook_ConditionHook", ConditionHook) or false
 			


### PR DESCRIPTION
> Wait for ARC9 to update my ass, i going to update ARC9 by myself! -Filipão

Added on the procedural stat system new conditions
1. MidAirCrouch
It was a condition that i needed alot in the past, now just adding here because it was just that easy to make...

``` lua
-- Example
    SWEP.RecoilMultMidAirCrouch = 2
```

//////

2. CHook
The CHook _(She Hulk)_ condition is a hook related function, where you can change any stat with this condition just with a trigger of CHook.

Here a example from the weapon Ember Celica using the Hook_ConditionHook:
``` lua
ATT.Hook_ConditionHook = function(self) -- ConditionHook = true

	local ply = self:GetOwner()
	
	local semblance = ply:Health() <= (ply:GetMaxHealth() / 100) * 35
	
	if semblance then
		ConditionHook = true
	else 
		ConditionHook = false
        end
end
```
``` lua
-- If ConditionHook is true, then these stats will take effect without needing the weapon to update.
SWEP.NumAddCHook = 2
SWEP.SpreadCHook = 0.15
SWEP.RecoilMultCHook = 0.75
```

This works, but it can be improved.

It is recommended to have the ConditionHook on the main weapon. Since if you remove the Attachment with the hook, if the CHook condition is "true" then will still be "true", since the hook code that should disable it doesn't exist.

The stats that has CHook, its recommended to be on Attachments in case you use multiple and diferrent ConditionHook triggers.

the Hook_TranslateAnimation will recognize ConditionHook.

//////

3. Water
Now theres a condition when you get fully submerged in water, this will trigger the stats.

``` lua
-- Example
    SWEP.ShootSoundWater = "arc9/aps/underwater/fire.wav"
    SWEP.PhysBulletMuzzleVelocityWater = 50 * 39.37 -- Meters per second
```

//////

4. M2
Differently from the Sights condition, only holding the M2 button will trigger the stats.
``` lua
    SWEP.SpreadMultM2 = 0.5
```