### PR TITLE
Fix of backstab not being disabled

### DIFF
--- a/lua/weapons/arc9_base/sh_melee.lua
+++ b/lua/weapons/arc9_base/sh_melee.lua
@@ -45,9 +45,11 @@ function SWEP:MeleeAttack(bypass, bash2)
         if tr.Entity:IsPlayer() or tr.Entity:IsNPC() or tr.Entity:IsNextBot() then
             self:SetLungeEntity(tr.Entity)
 
-            local dot = owner:EyeAngles():Forward():Dot(tr.Entity:EyeAngles():Forward())
+			if self:GetProcessedValue("Backstab") then
+            	local dot = owner:EyeAngles():Forward():Dot(tr.Entity:EyeAngles():Forward())
 
-            backstab = dot > 0
+            	backstab = dot > 0
+			end
         end
     end
 

--- a/lua/weapons/arc9_base/sh_melee.lua
+++ b/lua/weapons/arc9_base/sh_melee.lua
@@ -45,7 +45,7 @@ function SWEP:MeleeAttack(bypass, bash2)
         if tr.Entity:IsPlayer() or tr.Entity:IsNPC() or tr.Entity:IsNextBot() then
             self:SetLungeEntity(tr.Entity)
 
-			if self:GetProcessedValue("Backstab") then
+			if self:GetProcessedValue("Backstab", true) then
             	local dot = owner:EyeAngles():Forward():Dot(tr.Entity:EyeAngles():Forward())
 
             	backstab = dot > 0


### PR DESCRIPTION
It might be dumb why this became an issue for me, but for somereason, the Backstab condition was working regardless of the SWEP.Backstab is true or false. The issues it was doing is blocking the Lunge from bash and bash2 from moving the player, also it was using stats of backstab and backstab sound.