### PR TITLE
No longer gives you pistol ammo for Middle clicked Spawned weapons

### DIFF
--- a/lua/weapons/arc9_base/shared.lua
+++ b/lua/weapons/arc9_base/shared.lua
@@ -331,7 +331,8 @@ SWEP.ShootAngOffset = Angle(0, 0, 0)
 
 -------------------------- MAGAZINE
 
-SWEP.Ammo = "pistol" -- What ammo type this gun uses.
+SWEP.Ammo = "" -- What ammo type this gun uses.
+SWEP.Primary.Ammo = SWEP.Ammo
 
 SWEP.ChamberSize = 1 -- The amount of rounds this gun can chamber.
 SWEP.ClipSize = 25 -- Self-explanatory.


### PR DESCRIPTION
For whatever reason GMOD looks for Primary.Ammo first in the shared.lua. Despite the sh_init.lua replacing that value with SWEP.Ammo, Gmod will not use sh_init's replacement and will instead use shared.lua. I also tried making SWEP.Ammo blank without SWEP.Primary.Ammo and it still gives you Weapon_Pistol. So in this fix, this will make it so any middle clicked spawned weapons or HL2 weapon replacements will no longer give you weapon_pistol ammo.