### PR TITLE
Resolved depth buffer adaptation p.2

### DIFF
--- a/lua/weapons/arc9_base/cl_vm.lua
+++ b/lua/weapons/arc9_base/cl_vm.lua
@@ -166,6 +166,7 @@ function SWEP:PreDrawViewModel(vm, weapon, ply, flags)
 
     -- self:DrawCustomModel(true, EyePos() + EyeAngles():Forward() * 16, EyeAngles())
 
+	self.RenderingRTScope = false 
 	if !isDepthPass then
     	vm:SetSubMaterial()
 
@@ -175,14 +176,11 @@ function SWEP:PreDrawViewModel(vm, weapon, ply, flags)
     	        vm:SetSubMaterial(ind, val)
     	    end
     	end
-	end
 
-    self.RenderingRTScope = false 
-    if self:GetHolsterTime() < CurTime() and self.RTScope and sightamount > 0 then
-        self:DoRTScope(vm, self:GetTable(), sightamount > 0)
-    end
+    	if self:GetHolsterTime() < CurTime() and self.RTScope and sightamount > 0 then
+    	    self:DoRTScope(vm, self:GetTable(), sightamount > 0)
+    	end
 
-	if !isDepthPass then
     	vm:SetMaterial(self:GetProcessedValue("Material", true))
 	end
 


### PR DESCRIPTION
Rubat make update on `dev` branch with completed request [#3032](https://github.com/Facepunch/garrysmod-requests/issues/3032) with new `flags` argument to `WEAPON:PreDrawViewModel` and `WEAPON:PostDrawViewModel`. So we can avoid:
- running function like `SetMaterial` - Depthbuffer works only own mats with `DepthWrite` shader.
- render DoF, Holosight, DoRTScope, surface funcs, effects of smoke from suppressor shot.