### PR TITLE
Transfer attachments on duplicate weapon pickup

### DIFF
--- a/lua/arc9/server/sv_npc.lua
+++ b/lua/arc9/server/sv_npc.lua
@@ -219,8 +219,10 @@ end
 
 hook.Add("Think", "ARC9_Think_TryRandomize", ARC9.TryRandomize)
 
+local arc9_free_atts = GetConVar("arc9_free_atts")
+
 local function randomizaegun(wpn)
-    if !GetConVar("arc9_free_atts"):GetBool() then return end
+    if !arc9_free_atts:GetBool() then return end
     wpn:SetNoPresets(true)
 
     timer.Simple(0.1, function()
@@ -353,7 +355,7 @@ end
 
 hook.Add("PlayerCanPickupWeapon", "ARC9_PickupAttachmentTransfer", function(ply, wep)
     if !wep.ARC9 then return end
-    if GetConVar("arc9_free_atts"):GetBool() then return end
+    if arc9_free_atts:GetBool() then return end
     if !ply:HasWeapon(wep:GetClass()) then return end
 
     local atts = ExtractInstalledAtts(wep.Attachments)
@@ -368,7 +370,7 @@ function ARC9.SendPreset(ply, classname, preset)
 	local swep = list.Get( "Weapon" )[classname]
 	if swep == nil then return end
 
-    if !GetConVar("arc9_free_atts"):GetBool() then
+    if !arc9_free_atts:GetBool() then
         local atts = ARC9.GetAttsFromPreset(preset)
         if !atts then return end
 


### PR DESCRIPTION
Problem: When a player picks up a weapon they already own, the ground weapon's attachments are silently discarded.

Fix: Added a PlayerCanPickupWeapon hook that extracts all installed attachments from the ground weapon and transfers them to the player's inventory before the weapon is removed. This uses the existing ARC9.GiveAttsFromList function. Skipped when arc9_free_atts is enabled (attachments are unlimited).

Testing: Tested in singleplayer and multiplayer with polyarms— dropping a weapon with attachments and picking it up while already holding the same weapon class correctly transfers all attachments to the player's inventory.