### PR TITLE
Third Person shoulder aim option

### DIFF
--- a/lua/arc9/client/cl_thirdperson.lua
+++ b/lua/arc9/client/cl_thirdperson.lua
@@ -35,7 +35,8 @@ function ARC9.CalcView( ply, pos, angles, fov )
     -- if wpn:BeingOvertaken() then return end
 
     if !cam_enabled then return end
-    if wpn:GetInSights() then return end
+    --if wpn:GetInSights() then return end
+	if wpn:GetInSights() and wpn.IronSights["ForceFP"] then return end -- (wpn.IronSights["Scope"] or !GetConVar("arc9_thirdperson_sights"))
     --if wpn:GetSightAmount() >= 0.1 then return end
 
     -- local targetfov = GetConVar("ARC9_fov"):GetFloat()
@@ -148,7 +149,7 @@ function ARC9.InputMouseApply( cmd, x, y, ang )
     local wpn = ply:GetActiveWeapon()
     local turnspeed = ARC9.TurningSpeed
 
-    if !IsValid(wpn) or !wpn.ARC9 or wpn:GetInSights() then--wpn:GetSightAmount() >= 0.1 then
+    if !IsValid(wpn) or !wpn.ARC9 or (wpn:GetInSights() and wpn.IronSights["ForceFP"]) then
         ARC9.RelativeCamAngles = EyeAngles()
         ARC9.RelativePlayerAngles = EyeAngles()
         ARC9.RealCamAng = EyeAngles()


### PR DESCRIPTION
Hello again, so i been wondering in the base code if i could change the third person camera in the SWEP itself, but sadly is hard coded, so i decided to tweak it and turns out to work great at least in my weapon pack.

_Video for demonstration:_
https://github.com/user-attachments/assets/52bc8b37-5588-41ad-adfa-edaf32a2f8b4

However, it required to put in `SWEP.Ironsights` the `CrosshairInSights` enabled and a new variable `ForceFP` for scopes so the thirdperson camera force uses First person, i tried to check for ATT `Sights` or `RTScope` with only `wpn.` but no success with it. _(It means is required to update weapon code to use this feature)_

The changes only requires some line of codes edited, a extra variable in the ironsights and **a ConVar to enable it** _(must be admin only due Third Person camera not having recoil)_. If possible, a way to invert `arc9_cam_shoulder` value with a keybind and being able to set camera position.