### PR TITLE
Remove stickers from Depth Pass from `DrawCustomModel`

### DIFF
--- a/lua/weapons/arc9_base/cl_drawmodel.lua
+++ b/lua/weapons/arc9_base/cl_drawmodel.lua
@@ -92,7 +92,7 @@ function SWEP:DrawCustomModel(wm, custompos, customang, isDepthPass)
 
             if !IsValid(model) then self:KillModel() return end
 
-            if isDepthPass and atttbl.StickerMaterial then return end
+            if isDepthPass and atttbl.StickerMaterial then continue end
 
             if !onground or model.OptimizPrevWMPos != self:GetPos() then -- mega optimiz
                 model.OptimizPrevWMPos = onground and self:GetPos() or nil

--- a/lua/weapons/arc9_base/cl_drawmodel.lua
+++ b/lua/weapons/arc9_base/cl_drawmodel.lua
@@ -30,7 +30,7 @@ function SWEP:ShouldLOD()
     return result
 end
 
-function SWEP:DrawCustomModel(wm, custompos, customang)
+function SWEP:DrawCustomModel(wm, custompos, customang, isDepthPass)
     local owner = self:GetOwner()
 
     if !wm and !IsValid(owner) then return end
@@ -48,7 +48,7 @@ function SWEP:DrawCustomModel(wm, custompos, customang)
         else
             mdl = self.WModel
 
-            if lod == 0 and mdl and mdl[1]:IsValid() then
+            if !isDepthPass and lod == 0 and mdl and mdl[1]:IsValid() then
                 mdl[1]:SetMaterial(self:GetProcessedValue("Material", true))
 
                 for ind = 0, 31 do
@@ -91,6 +91,8 @@ function SWEP:DrawCustomModel(wm, custompos, customang)
             local atttbl = self:GetFinalAttTable(slottbl)
 
             if !IsValid(model) then self:KillModel() return end
+
+            if isDepthPass and atttbl.StickerMaterial then return end
 
             if !onground or model.OptimizPrevWMPos != self:GetPos() then -- mega optimiz
                 model.OptimizPrevWMPos = onground and self:GetPos() or nil
@@ -181,7 +183,7 @@ function SWEP:DrawCustomModel(wm, custompos, customang)
             if !model.NoDraw and !(model.istranslucent and !ARC9.PresetCam and !onground and !isnpc) then
                 -- if !wm then model:SetRenderOrigin(self.ViewModelPos or (IsValid(self:GetVM()) and self:GetVM():GetPos() or self:GetPos())) end
                 model:DrawModel()
-                if drawprojlights:GetBool() or rttenabled == false then render.RenderFlashlights(function() model:DrawModel() end) end
+                if !isDepthPass and drawprojlights:GetBool() or rttenabled == false then render.RenderFlashlights(function() model:DrawModel() end) end
             end
 
             if atttbl.DrawFunc then

--- a/lua/weapons/arc9_base/cl_drawmodel.lua
+++ b/lua/weapons/arc9_base/cl_drawmodel.lua
@@ -30,7 +30,9 @@ function SWEP:ShouldLOD()
     return result
 end
 
-function SWEP:DrawCustomModel(wm, custompos, customang, isDepthPass)
+function SWEP:DrawCustomModel(wm, custompos, customang, flags)
+    flags = flags or STUDIO_RENDER
+    local isDepthPass = ( bit.band( flags, STUDIO_SSAODEPTHTEXTURE ) != 0 || bit.band( flags, STUDIO_SHADOWDEPTHTEXTURE ) != 0 )
     local owner = self:GetOwner()
 
     if !wm and !IsValid(owner) then return end

--- a/lua/weapons/arc9_base/cl_drawmodel.lua
+++ b/lua/weapons/arc9_base/cl_drawmodel.lua
@@ -185,7 +185,7 @@ function SWEP:DrawCustomModel(wm, custompos, customang, flags)
             if !model.NoDraw and !(model.istranslucent and !ARC9.PresetCam and !onground and !isnpc) then
                 -- if !wm then model:SetRenderOrigin(self.ViewModelPos or (IsValid(self:GetVM()) and self:GetVM():GetPos() or self:GetPos())) end
                 model:DrawModel()
-                if !isDepthPass and drawprojlights:GetBool() or rttenabled == false then render.RenderFlashlights(function() model:DrawModel() end) end
+                if !isDepthPass and (drawprojlights:GetBool() or rttenabled == false) then render.RenderFlashlights(function() model:DrawModel() end) end
             end
 
             if atttbl.DrawFunc then

--- a/lua/weapons/arc9_base/cl_vm.lua
+++ b/lua/weapons/arc9_base/cl_vm.lua
@@ -205,7 +205,7 @@ function SWEP:ViewModelDrawn(ent, flags)
     local isDepthPass = ( bit.band( flags, STUDIO_SSAODEPTHTEXTURE ) != 0 || bit.band( flags, STUDIO_SHADOWDEPTHTEXTURE ) != 0 )
 	
     self.StoredVMAngles = self:GetCameraControl()
-    self:DrawCustomModel(false, nil, nil, isDepthPass)
+    self:DrawCustomModel(false, nil, nil, flags)
     render.DepthRange( 0.0, 0.1 )
     self:DoRHIK()
     if ARC9.RTScopeRender then return end

--- a/lua/weapons/arc9_base/cl_vm.lua
+++ b/lua/weapons/arc9_base/cl_vm.lua
@@ -205,7 +205,7 @@ function SWEP:ViewModelDrawn(ent, flags)
     local isDepthPass = ( bit.band( flags, STUDIO_SSAODEPTHTEXTURE ) != 0 || bit.band( flags, STUDIO_SHADOWDEPTHTEXTURE ) != 0 )
 	
     self.StoredVMAngles = self:GetCameraControl()
-    self:DrawCustomModel(false)
+    self:DrawCustomModel(false, nil, nil, isDepthPass)
     render.DepthRange( 0.0, 0.1 )
     self:DoRHIK()
     if ARC9.RTScopeRender then return end

--- a/lua/weapons/arc9_base/cl_wm.lua
+++ b/lua/weapons/arc9_base/cl_wm.lua
@@ -1,6 +1,6 @@
 -- local goodmin, goodmax, extramax = Vector(-16, -16, -16), Vector(16, 16, 16), Vector(16, 16, 2048)
 
-function SWEP:DrawWorldModel()
+function SWEP:DrawWorldModel(flags)
     local owner = self:GetOwner()
 
     if !self.MirrorVMWM or (!IsValid(owner) and self.MirrorVMWMHeldOnly) then
@@ -8,7 +8,7 @@ function SWEP:DrawWorldModel()
         return
     end
 
-    self:DrawCustomModel(true)
+    self:DrawCustomModel(true, nil, nil, flags)
 
 
     if IsValid(owner) and owner:GetActiveWeapon() == self then -- gravgun moment


### PR DESCRIPTION
This pull request get `flags` arg from `ViewModelDrawn` and `DrawWorldModel` functions and then input to `DrawCustomModel` as 4th arg. Then in `DrawCustomModel` func avoided funcs `SetMaterial` if `isDepthPass` is `true`. Also added `atttbl.StickerMaterial` check for depth pass to fix resolved depth buffer issue. It also remove stickers both from world model and view model.

<details>
  <summary>Before:</summary>

<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/1b2013d6-8064-45d7-bc76-c609bafa3008" />

<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/9850fef2-f651-46c7-a200-2c3137559657" />

</details>

<details>
  <summary>After:</summary>
  
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/488d7e35-3d2e-4e8a-a435-4d4b0bb7afcd" />

<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/4ef010b7-8cdd-46ed-a81c-d0c2b0d6515d" />

</details>
