### PR TITLE
add RecoilKickPitchMult stat

### DIFF
--- a/lua/weapons/arc9_base/cl_camera.lua
+++ b/lua/weapons/arc9_base/cl_camera.lua
@@ -31,7 +31,7 @@ function SWEP:CalcView(ply, pos, ang, fov)
         if !self:IsUsingRTScope() then
             local recam = math.min(swepDt.RecoilAmount, 15)
             SmoothRecoilAmount = Lerp(FrameTime() * 3, SmoothRecoilAmount, recam)
-            local thing = SmoothRecoilAmount * (reckick * self:GetProcessedValue("RecoilKickPitchMult")) * self:GetProcessedValue("Recoil")
+            local thing = SmoothRecoilAmount * (reckick * self:GetProcessedValue("RecoilKickPitchMult", true)) * self:GetProcessedValue("Recoil")
             ang.p = ang.p - 0.6 * thing
             self.VMZOffsetForCamera = -0.25 * thing
         end

--- a/lua/weapons/arc9_base/cl_camera.lua
+++ b/lua/weapons/arc9_base/cl_camera.lua
@@ -14,7 +14,7 @@ local swepGetProcessedValue = SWEP.GetProcessedValue
 
 function SWEP:CalcView(ply, pos, ang, fov)
     if self:GetOwner():ShouldDrawLocalPlayer() then return end
-    
+
     local swepDt = self.dt
     if !swepGetProcessedValue then swepGetProcessedValue = self.GetProcessedValue end
 
@@ -31,7 +31,7 @@ function SWEP:CalcView(ply, pos, ang, fov)
         if !self:IsUsingRTScope() then
             local recam = math.min(swepDt.RecoilAmount, 15)
             SmoothRecoilAmount = Lerp(FrameTime() * 3, SmoothRecoilAmount, recam)
-            local thing = SmoothRecoilAmount * reckick * self:GetProcessedValue("Recoil")
+            local thing = SmoothRecoilAmount * (reckick * self:GetProcessedValue("RecoilKickPitchMult")) * self:GetProcessedValue("Recoil")
             ang.p = ang.p - 0.6 * thing
             self.VMZOffsetForCamera = -0.25 * thing
         end
@@ -87,9 +87,9 @@ function SWEP:GetSmoothedFOVMag()
         end
 
 		if !shotgun and fuckingreloadprocess < (reloadanim.PeekProgress or reloadanim.MinProgress or 0.9) then target = target * 0.95 end
-			
+
 		if shotgun and swepDt.Reloading then target = target * 0.95 end
-		
+
         local sightdelta2 = math.ease.InCirc(sightdelta_old)
         mag = Lerp(sightdelta, 1, Lerp(sightdelta2, target2, target))
 
@@ -115,7 +115,7 @@ function SWEP:GetCameraControl(wm)
     if !swepGetProcessedValue then swepGetProcessedValue = self.GetProcessedValue end
 
     local seqprox = swepDt.SequenceProxy
-	
+
 	if swepDt.Customize then return end
 
     local camstrength, rollstrength = 1, 1
@@ -162,7 +162,7 @@ function SWEP:GetCameraControl(wm)
         if !camqca then return end
 
         local vm = self:GetVM()
-        
+
         if !IsValid(vm) then return end
 
         local ang = (vm:GetAttachment(camqca) or {}).Ang
@@ -176,7 +176,7 @@ function SWEP:GetCameraControl(wm)
             local ft = FrameTime()
 
             self.ProceduralViewOffset:Normalize()
-            
+
             ang:Normalize()
             local delta = self.LastMuzzleAngle - ang
             delta:Normalize()

--- a/lua/weapons/arc9_base/shared.lua
+++ b/lua/weapons/arc9_base/shared.lua
@@ -106,14 +106,14 @@ SWEP.WorldModelOffset = nil
 --     Ang = Angle(0, 0, 0),
 --     TPIKPos = Vector(0, 0, 0), -- arc9_tpik 1, you can make cool poses with it
 --     TPIKAng = Angle(0, 0, 0),
--- 
+--
 --     TPIKPosSightOffset = Vector(0, 0, 0), -- ironsights offset, disable NoTPIKVMPos
 --     TPIKPosReloadOffset = Vector(0, 0, 0), -- reload offset if arms stretching too much during reloads
 --     TPIKAngReloadOffset = Angle(0, 0, 0),
 --     TPIKHolsterOffset = Angle(0, 0, 0), -- for passive/normal holdtype
 
 --     TPIKPosAlternative = Vector(0, 0, 0) -- enabled with SWEP/ATT.TPIKAlternativePos = true
--- 
+--
 --     Scale = 1
 -- }
 SWEP.NoTPIK = false
@@ -372,7 +372,7 @@ SWEP.AutoReload = false -- When the gun is drawn, it will automatically reload.
 SWEP.ShouldDropMag = false
 SWEP.ShouldDropMagEmpty = true
 
-SWEP.DropMagazineModel = nil -- Set to a string or table to drop this magazine when reloading.  
+SWEP.DropMagazineModel = nil -- Set to a string or table to drop this magazine when reloading.
 SWEP.DropMagazineSounds = {} -- Table of sounds a dropped magazine should play.
 SWEP.DropMagazineAmount = 1 -- Amount of mags to drop.
 SWEP.DropMagazineSkin = 0 -- Model skin of mag.
@@ -540,7 +540,7 @@ SWEP.VisualRecoilDampingConst = nil -- How spring will be visual recoil, 120 is 
 SWEP.VisualRecoilSpringMagnitude = 1
 SWEP.VisualRecoilSpringPunchDamping = nil -- ehh another val for "eft" recoil, 6 is default
 
-SWEP.VisualRecoilThinkFunc = nil -- wawa, override DampingConst, SpringMagnitude, SpringPunchDamping here 
+SWEP.VisualRecoilThinkFunc = nil -- wawa, override DampingConst, SpringMagnitude, SpringPunchDamping here
 -- function(springconstant, VisualRecoilSpringMagnitude, PUNCH_DAMPING, recamount)
 --     if recamount > 3 then
 --         return springconstant * 100, VisualRecoilSpringMagnitude * 1, PUNCH_DAMPING * 1
@@ -548,7 +548,7 @@ SWEP.VisualRecoilThinkFunc = nil -- wawa, override DampingConst, SpringMagnitude
 --     return springconstant, VisualRecoilSpringMagnitude, PUNCH_DAMPING
 -- end
 
-SWEP.VisualRecoilDoingFunc = nil -- wawa, override Up, Side, Roll here 
+SWEP.VisualRecoilDoingFunc = nil -- wawa, override Up, Side, Roll here
 -- function(up, side, roll, punch, recamount)
 --     if recamount > 2 then
 --         return up * 5, side * 1.5, roll, punch * 0.9
@@ -559,6 +559,7 @@ SWEP.VisualRecoilDoingFunc = nil -- wawa, override Up, Side, Roll here
 SWEP.RecoilKick = 1 -- Camera recoil
 SWEP.RecoilKickDamping = 70.151 -- Camera recoil damping
 SWEP.RecoilKickAffectPitch = nil -- thing for eft, set to true if you want camera go up (only visually) as recoil increases, SWEP.Recoil * SWEP.RecoilKick = effect of this
+SWEP.RecoilKickPitchMult = 1 -- If recoil kick affects pitch, how much will the effect of the RecoilKick stat apply to the pitch
 
 -- Additional subtle visual recoil, in case your gun doesn't have animated fire. Acts like a second spring added on top with limited duration
 -- SWEP.SubtleVisualRecoil = 1 -- multiplier, set to something to enable this thing


### PR DESCRIPTION
Adds a stat that affects the intensity of the `RecoilKick` stat when affecting the pitch of a weapon when `RecoilKickAffectPitch` is ENABLED. Allows you to use higher `RecoilKick` values without having the effect of the pitch be too jarring, especially on weapons like shotguns or snipers that might benefit from the added shake of the `RecoilKick` stat.