### PR TITLE
Fix clientside lua errors on startup with arc9_phystweak enabled on x86-64 branch

### DIFF
--- a/lua/arc9/common/sh_common.lua
+++ b/lua/arc9/common/sh_common.lua
@@ -468,11 +468,13 @@ end
 hook.Add("InitPostEntity", "ARC9_phystweak", function() -- stolen from tacrp
     if GetConVar("arc9_phystweak"):GetBool() then
         if !physenv or !physenv.GetPerformanceSettings then print("[ARC9] How the hell you don't have physenv???? wtf wrong with your game") return end
-        local v = physenv.GetPerformanceSettings().MaxVelocity or 10000
-        if v < 10000 then
-            physenv.SetPerformanceSettings({MaxVelocity = 10000})
-            print("[ARC9] Increasing MaxVelocity for projectiles to behave as intended! (" .. v .. "-> 10000)")
-            print("[ARC9] Disable this behavior with 'arc9_phystweak 0'.")
-        end
+        timer.Simple(0, function() -- Add timer because using physenv.GetPerformanceSettings() function immediately returns nil
+            local v = physenv.GetPerformanceSettings().MaxVelocity or 10000
+            if v < 10000 then
+                physenv.SetPerformanceSettings({MaxVelocity = 10000})
+                print("[ARC9] Increasing MaxVelocity for physics objects to make sure bullet projectiles behave as intended! (" .. v .. "-> 10000)")
+                print("[ARC9] Disable this behavior with 'arc9_phystweak 0'.")
+            end
+        end)
     end
 end)

--- a/lua/arc9/common/sh_common.lua
+++ b/lua/arc9/common/sh_common.lua
@@ -468,7 +468,7 @@ end
 hook.Add("InitPostEntity", "ARC9_phystweak", function() -- stolen from tacrp
     if GetConVar("arc9_phystweak"):GetBool() then
         if !physenv or !physenv.GetPerformanceSettings then print("[ARC9] How the hell you don't have physenv???? wtf wrong with your game") return end
-        timer.Simple(0, function() -- Add timer because using physenv.GetPerformanceSettings() function immediately returns nil
+        timer.Simple(0, function()
             local v = physenv.GetPerformanceSettings().MaxVelocity or 10000
             if v < 10000 then
                 physenv.SetPerformanceSettings({MaxVelocity = 10000})


### PR DESCRIPTION
Fixes clientside lua errors for the function in InitPostEntity with arc9_phystweak enabled on the x86-64 branch.

Running physenv.GetPerformanceSettings() immediately in InitPostEntity hook returns nil;
And because there is no check for if the table is not nil, it creates a lua error when trying to get value physenv.GetPerformanceSettings().MaxVelocity as because the physenv.GetPerformanceSettings() table is nil, which could potentially break other addons.

To fix this issue, I added a timer function with 0s duration, executing the same function, although it runs AFTER InitPostEntity. This means, that running physenv.GetPerformanceSettings() function now returns a table and allows setting the MaxVelocity variable. This small change prevents causing any lua errors on startup with arc9_phystweak 1.