### PR TITLE
Add infinite hold breath toggle in settings

### DIFF
--- a/lua/arc9/client/cl_settings_menu.lua
+++ b/lua/arc9/client/cl_settings_menu.lua
@@ -256,6 +256,7 @@ ARC9.SettingsTable = {
         { type = "label", text = "settings.tabname.features", desc = "settings.tabname.features.desc" },
         { sv = true, type = "bool", text = "settings.server.gameplay.mod_sway.title", desc = "settings.server.gameplay.mod_sway.desc", convar = "mod_sway" },
         { sv = true, type = "bool", text = "settings.server.gameplay.breath_slowmo.title", desc = "settings.server.gameplay.breath_slowmo.desc", convar = "breath_slowmo" },
+        { sv = true, type = "bool", text = "settings.server.gameplay.breath_infinite.title", desc = "settings.server.gameplay.breath_infinite.desc", convar = "breath_infinite" },
         { type = "bool", text = "settings.gameplay.togglebreath.title", desc = "settings.gameplay.togglebreath.desc", convar = "togglebreath" },
         { type = "bool", text = "settings.centerhint.breath_hud.title", desc = "settings.centerhint.breath_hud.desc", convar = "breath_hud" },
         { type = "bool", text = "settings.centerhint.breath_pp.title", desc = "settings.centerhint.breath_pp.desc", convar = "breath_pp" },

--- a/lua/arc9/common/localization/base_en.lua
+++ b/lua/arc9/common/localization/base_en.lua
@@ -815,6 +815,9 @@ L["settings.server.gameplay.mod_sway.desc"] = "Enable weapon sway (if the weapon
 L["settings.server.gameplay.breath_slowmo.title"] = "Enable Slow-Mo when Holding Breath (Singleplayer)"
 L["settings.server.gameplay.breath_slowmo.desc"] = "! Singleplayer Only !\nHolding your breath slows down time."
 
+L["settings.server.gameplay.breath_infinite.title"] = "Infinite Hold Breath"
+L["settings.server.gameplay.breath_infinite.desc"] = "Holding your breath does not drain the breath meter."
+
 L["settings.gameplay.togglebreath.title"] = "Toggle Holding Breath"
 L["settings.gameplay.togglebreath.desc"] = "Pressing your sprint button toggles holding breath."
 

--- a/lua/arc9/common/sh_0_convar.lua
+++ b/lua/arc9/common/sh_0_convar.lua
@@ -380,6 +380,11 @@ local conVars = {
         replicated = true
     },
     {
+        name = "breath_infinite",
+        default = "0",
+        replicated = true
+    },
+    {
         name = "ricochet",
         default = "1",
         replicated = true

--- a/lua/weapons/arc9_base/sh_shoot.lua
+++ b/lua/weapons/arc9_base/sh_shoot.lua
@@ -2,6 +2,7 @@ local cancelmults = ARC9.CancelMultipliers[engine.ActiveGamemode()] or ARC9.Canc
 
 local swepGetProcessedValue = SWEP.GetProcessedValue
 local swepGetValue = SWEP.GetValue
+local infbreathconvar = GetConVar("arc9_breath_infinite")
 
 local sp = game.SinglePlayer()
 
@@ -474,7 +475,7 @@ function SWEP:DoPrimaryAttack()
     self:DoEffects()
 
 
-    if self:HoldingBreath() then
+    if self:HoldingBreath() and !infbreathconvar:GetBool() then
         local d = 100 / math.max(1, swepGetProcessedValue(self, "HoldBreathTime", true))
         local breathtake = math.Clamp(delay * d * 3, 1, 10)
         if manualaction then

--- a/lua/weapons/arc9_base/sh_sway.lua
+++ b/lua/weapons/arc9_base/sh_sway.lua
@@ -2,6 +2,7 @@ SWEP.SetBreathDSP = false
 
 local sfxconvar = GetConVar("arc9_breath_sfx")
 local slomoconvar = GetConVar("arc9_breath_slowmo")
+local infbreathconvar = GetConVar("arc9_breath_infinite")
 local togglconvar = GetConVar("arc9_togglebreath")
 local ppconvar = GetConVar("arc9_breath_pp")
 local hudconvar = GetConVar("arc9_breath_hud")
@@ -14,11 +15,18 @@ function SWEP:ThinkHoldBreath()
     if holdbreathtime <= 0 then return end
 
     local sfx = sfxconvar:GetBool()
+    local infinitebreath = infbreathconvar:GetBool()
 
     local target_ts = 1
 
     if self:HoldingBreath() then
-        self:SetBreath(self:GetBreath() - (FrameTime() * 100 / holdbreathtime))
+        if infinitebreath then
+            self:SetBreath(100)
+            self:SetOutOfBreath(false)
+        else
+            self:SetBreath(self:GetBreath() - (FrameTime() * 100 / holdbreathtime))
+        end
+
         if self:GetBreath() < 0 then
             self:SetOutOfBreath(true)
             self:SetBreath(0)
@@ -93,7 +101,7 @@ function SWEP:ThinkHoldBreath()
 end
 
 function SWEP:CanHoldBreath()
-    return self:GetBreath() > 0 and !self:GetOutOfBreath()
+    return infbreathconvar:GetBool() or (self:GetBreath() > 0 and !self:GetOutOfBreath())
 end
 
 local lastpressed = false


### PR DESCRIPTION
Adds a replicated `arc9_breath_infinite` gameplay setting, exposes it in the ARC9 settings menu, and prevents breath drain from both holding breath and shooting while enabled.

I was messing around in sandbox and I thought it would be something kinda cool to add, so I went ahead and did it. 

I was looking at the developer documentation that was available, but if I missed something, let me know! If for whatever reason this isn't something you want in the base, that's cool too. Just thought id make a PR in case. 